### PR TITLE
Added process diffuser and several improvements.

### DIFF
--- a/diffuse/__init__.py
+++ b/diffuse/__init__.py
@@ -1,11 +1,13 @@
 __version__ = "0.1.0"
 
 import enum
-from diffuse.diffuser import thread, async_diffuser
+from diffuse.diffuser import thread, async_diffuser, process
+
 
 
 class Diffuser(enum.Enum):
     THREAD = thread.ThreadDiffuser
+    PROCESS = process.ProcessDiffuser
     ASYNC = async_diffuser.AsyncDiffuser
 
     @classmethod

--- a/diffuse/diffuser/async_diffuser.py
+++ b/diffuse/diffuser/async_diffuser.py
@@ -1,11 +1,10 @@
 import asyncio
-import math
-
-from diffuse.worker import async_worker
-from diffuse.diffuser import base
-
 import logging
+import math
 import threading
+
+from diffuse.diffuser import base
+from diffuse.worker import async_worker
 
 LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +28,7 @@ class _AsyncTask(object):
             self.future.set_exception(exc)
         else:
             self.future.set_result(result)
+            return result
 
 
 class AsyncDiffuser(base._ASyncDiffuser):

--- a/diffuse/diffuser/base.py
+++ b/diffuse/diffuser/base.py
@@ -82,10 +82,13 @@ class _BaseDiffuser:
         returned. However, starting the worker is implementation specific and
         left with diffuser to do.
         """
-        if self._worker_pool.size >= self.max_workers:
+
+        # No need to initialize new worker if there aren't any pending tasks in
+        # queue.
+        if not self.task_queue.qsize():
             return
 
-        if self._worker_pool.size >= self.task_queue.qsize():
+        if self._worker_pool.size >= self.max_workers:
             return
 
         worker = self._WORKER_CLASS(self.task_queue, self._ephemeral, None)

--- a/diffuse/diffuser/process.py
+++ b/diffuse/diffuser/process.py
@@ -1,0 +1,170 @@
+import logging
+import multiprocessing
+import queue
+import threading
+import time
+from concurrent import futures
+
+from diffuse.diffuser import base
+from diffuse.worker import process as process_worker
+
+LOGGER = logging.getLogger(__name__)
+
+
+class _TaskInstance(object):
+    """
+    Reflects the object that is added to task queue.
+
+    Since tasks are processed in separate child process, sending the actual task
+    and setting future result there won't cascade the result back to client. So,
+    instead we send this instance in queue which holds the reference to task
+    result/exception depending on how task was executed. The child process then
+    adds the same task instance to result queue which is read by separate result
+    processing thread.
+    """
+
+    def __init__(self, target, *args, **kwargs):
+        self.id = id(self)
+
+        self.target = target
+        self.args = args
+        self.kwargs = kwargs
+        self.result = None
+        self.exception = None
+
+    def run(self):
+        """
+        Calls the task target with supplied args and kwargs parameters, and
+        keeps reference to task output/exception.
+        """
+        try:
+            self.result = self.target(*self.args, **self.kwargs)
+        except BaseException as exc:
+            self.exception = exc
+
+        return self
+
+
+class _Task(object):
+    def __init__(self, target, *args, **kwargs):
+        self.future = futures.Future()
+        self.instance = _TaskInstance(target, *args, **kwargs)
+
+
+class ProcessDiffuser(base._SyncDiffuser):
+    """
+    A diffuser implementation that executes tasks in separate child process.
+    """
+
+    _WORKER_CLASS = process_worker.ProcessWorker
+    _TASK_CLASS = _Task
+    _QUEUE_EMPTY_EXCEPTION = queue.Empty
+
+    def __init__(self, target, ephemeral=False, max_workers=None):
+
+        if max_workers is None:
+            max_workers = multiprocessing.cpu_count()
+
+        if max_workers <= 0:
+            raise ValueError("max_workers must be greater than 0")
+
+        if max_workers > multiprocessing.cpu_count():
+            raise ValueError(
+                "Worker count %s is more than supported by system (%s)",
+                max_workers,
+                multiprocessing.cpu_count(),
+            )
+
+        LOGGER.debug("Max workers: %s", max_workers)
+        self._max_workers = max_workers
+
+        self._task_queue = multiprocessing.Queue()
+        self._close_lock = threading.Lock()
+
+        super().__init__(target, ephemeral)
+
+        # Apart from task queue, we also need a result queue to receive results
+        # from worker processes.
+        self._result_queue = multiprocessing.Queue()
+
+        # Maintains the list of tasks that have been sent to workers for
+        # processing for which results haven't been received yet.
+        self._pending_tasks = {}
+
+        # Whether the stop result processor thread.
+        self._stop_result_processor = False
+
+        # A separate result processing thread that receives results pushed by
+        # child processes in result queue, and updates the associated task's
+        # future instance based on result.
+        self._result_processor = threading.Thread(
+            target=self._process_task_results
+        )
+        self._result_processor.start()
+
+    @property
+    def task_queue(self):
+        return self._task_queue
+
+    @property
+    def max_workers(self):
+        return self._max_workers
+
+    @property
+    def close_lock(self):
+        return self._close_lock
+
+    def _diffuse(self, task):
+        # Since task is processed in completely separate process, it would be
+        # hard to know when task actually started running. So, we set it to
+        # running as soon as task is submitted for processing.
+        # Also, the future state should be set at the earliest, as there are
+        # chances that task gets picked up by a worker as soon as it is added to
+        # queue, and for small tasks the processing might complete even before
+        # future state is set.
+        task.future.set_running_or_notify_cancel()
+
+        self._pending_tasks[task.instance.id] = task
+
+        super(ProcessDiffuser, self)._diffuse(task.instance)
+
+    def _worker_init_kwargs(self):
+        """
+        Sends result_queue to worker.
+        """
+        return {"result_queue": self._result_queue}
+
+    def _cleanup(self, wait):
+        """
+        Notifies result processor to shutdown.
+
+        Args:
+            wait: Whether to wait for all results to be processed from queue.
+        """
+        self._result_queue.put_nowait(None)
+
+        if wait:
+            self._result_processor.join()
+
+    def _process_task_results(self):
+        """
+        Retrieves task results from result queue and updates corresponding
+        future objects.
+        """
+        while not self._stop_result_processor:
+            task_instance = self._result_queue.get()
+            if task_instance is None:
+                self._stop_result_processor = True
+                continue
+
+            task = self._pending_tasks[task_instance.id]
+            # If task was already cancelled by user, skip further processing.
+            if task.future.cancelled():
+                return
+
+            if task_instance.result:
+                task.future.set_result(task_instance.result)
+            else:
+                task.future.set_exception(task_instance.exception)
+
+            del self._pending_tasks[task_instance.id]

--- a/diffuse/diffuser/thread.py
+++ b/diffuse/diffuser/thread.py
@@ -28,10 +28,9 @@ class _Task(object):
             # in event of an exception.
             LOGGER.error("Error while running target: %s", str(exc))
             self.future.set_exception(exc)
-            # Break a reference cycle with the exception 'exc'
-            self = None
         else:
             self.future.set_result(result)
+            return result
 
 
 class ThreadDiffuser(base._SyncDiffuser):

--- a/diffuse/pool.py
+++ b/diffuse/pool.py
@@ -1,4 +1,5 @@
 import logging
+import weakref
 
 LOGGER = logging.getLogger(__name__)
 
@@ -7,18 +8,21 @@ class WorkerPool:
     """Worker pool that keeps track of currently running worker processes."""
 
     def __init__(self):
-        self._workers = []
+        # Keep week ref for workers added to the pool. This simplifies pool
+        # logic as it is no longer required to keep track of dead workers.
+        self._workers = weakref.WeakSet()
 
     @property
     def size(self):
-        """The current pool size.
+        """
+        The current pool size.
 
         Returns the count of workers that are currently alive.
         """
-        self._workers = [
-            worker for worker in self._workers if worker.is_alive()
-        ]
-        return len(self._workers)
+        # Weekrefs are maintained till they are garbage collected. Simply
+        # returning the length of pool will give incorrect result in case worker
+        # is dead but not yet garbage collected.
+        return len([worker.is_alive() for worker in self._workers])
 
     def add(self, worker):
         """Adds a new worker to pool.
@@ -26,7 +30,7 @@ class WorkerPool:
         Args:
             worker: The implementation specific worker instance.
         """
-        self._workers.append(worker)
+        self._workers.add(worker)
 
     def shutdown(self, wait):
         """Shuts down pool and stops all the worker processes.
@@ -45,7 +49,7 @@ class WorkerPool:
         # Wait for worker processes to complete. Due to the way worker processes
         # decides that it is time to shutdown, joining of worker can't be done
         # just after workers are asked to stop above.
-        for task_worker in list(self._workers):
+        for task_worker in self._workers:
             task_worker.join()
             LOGGER.debug("Stopped worker: %s", task_worker.id)
 
@@ -58,7 +62,7 @@ class WorkerPool:
         if not wait:
             return
 
-        for task_worker in list(self._workers):
+        for task_worker in self._workers:
             await task_worker.join()
             LOGGER.debug("Stopped worker: %s", task_worker.id)
 
@@ -66,11 +70,13 @@ class WorkerPool:
         """Stops running worker processes."""
         LOGGER.debug("Shutting down worker pool.")
 
-        # When using ephemeral workers, the workers might have already stopped
-        # when this method is called. If that is the case, return.
-        if not self.size:
-            return
-
-        for task_worker in list(self._workers):
+        # Since task queue is shared among workers, stop signal sent to a worker
+        # might actually be read by completely different worker. This will
+        # result in the receiving worker initiating its termination process and
+        # getting auto evicted from pool due to weak reference.
+        # To make sure every worker receives stop signal at least once, we need
+        # to send as many signals as there are workers in pool.
+        workers_copy = [worker for worker in self._workers]
+        for task_worker in workers_copy:
             LOGGER.debug("Stopping worker: %s", task_worker.id)
             task_worker.stop()

--- a/diffuse/worker/async_worker.py
+++ b/diffuse/worker/async_worker.py
@@ -1,7 +1,7 @@
 import asyncio
-from diffuse.worker import base
-
 import logging
+
+from diffuse.worker import base
 
 LOGGER = logging.getLogger(__name__)
 
@@ -38,7 +38,8 @@ class AsyncWorker(base._BaseWorker):
             if task is None:
                 self._finished.set()
             else:
-                await task.run()
+                result = await task.run()
+                await self._process_result(result)
 
         LOGGER.debug(
             "%s - finished. Pending task count: %s",
@@ -54,3 +55,6 @@ class AsyncWorker(base._BaseWorker):
                 return None
 
         return await self._queue.get()
+
+    async def _process_result(self, result):
+        pass

--- a/diffuse/worker/base.py
+++ b/diffuse/worker/base.py
@@ -58,10 +58,16 @@ class _BaseWorker(object):
             if task is None:
                 self._is_done = True
             else:
-                task.run()
+                result = task.run()
+                self._process_result(result)
 
         LOGGER.debug(
             "Worker: %s - stopped. Pending task count: %s",
             self.id,
             self._queue.qsize(),
         )
+
+
+    def _process_result(self, result):
+        """Implementation specific processing of task result."""
+        pass

--- a/diffuse/worker/process.py
+++ b/diffuse/worker/process.py
@@ -1,0 +1,39 @@
+import logging
+import multiprocessing
+import queue
+
+from diffuse.worker import base
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ProcessWorker(multiprocessing.Process, base._BaseWorker):
+    """
+    A worker implementation that runs in a separate child process.
+
+    The order in which parent classes are inherited is important due to the way
+    python MRO works.
+    """
+
+    def __init__(self, queue, ephemeral, result_queue):
+        # Since Process is the first class mentioned in inheritance list, this
+        # call will go to Process class and make sure that worker process is
+        # correctly initialized.
+        super().__init__()
+
+        # This call is required to initialize the standalone worker
+        # functionality.
+        base._BaseWorker.__init__(self, queue, ephemeral)
+
+        self._result_queue = result_queue
+
+    @property
+    def id(self):
+        return "__".join((self.__class__.__name__, str(self.pid)))
+
+    def run(self):
+        """Overrides base implementation and calls worker's _run method."""
+        self._run()
+
+    def _process_result(self, result):
+        self._result_queue.put(result)

--- a/diffuse/worker/thread.py
+++ b/diffuse/worker/thread.py
@@ -1,6 +1,6 @@
 import threading
+
 from diffuse.worker import base
-import queue as thread_safe_queue
 
 
 class ThreadWorker(threading.Thread, base._BaseWorker):
@@ -28,11 +28,3 @@ class ThreadWorker(threading.Thread, base._BaseWorker):
     def run(self):
         """Overrides base implementation and calls worker's _run method."""
         self._run()
-
-    def _get_task(self):
-        try:
-            return self._queue.get(block=not self._ephemeral)
-        except thread_safe_queue.Empty:
-            pass
-
-        return None


### PR DESCRIPTION
- Use weak references to maintain list of workers in pool.
- Init worker only when there are unprocessed tasks in queue.
- Added methods to allow diffuser implementation to provide custom diffuse, cleanup actions and worker extra init args.
- Task runs now return the execution result that can be used by workers for further processing.
- Calling stop on ephemeral workers is a no-op now. Moved _get_task method to base class.
- Implemented process diffuser that executes tasks in separate child process.
