### PR TITLE
develop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "diffuse"
-version = "0.1.1"
+version = "0.2.0"
 description = "Python Diffuse"
 authors = ["Sandeep Aggarwal <asandeep.me@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
- Delay worker initialization for sync workers to allow available workers to pick up task.
- Introduce idle timeout for ephemeral workers to prevent aggressive killing when processing short-lived tasks.
- Bumped up package version.
